### PR TITLE
Fix unicode escape

### DIFF
--- a/scripts/metrics.js
+++ b/scripts/metrics.js
@@ -167,7 +167,7 @@ setEventHandler(function(evt) {
         var delUrl = url + '/' + idx;
         try {
           http(delUrl, 'DELETE', null, null, headers);
-          logInfo("\u1F5D1\uFE0F Rule auto-unban (DELETE) untuk " + ruleKey + " dengan idx: " + idx);
+          logInfo("\u{1F5D1}\uFE0F Rule auto-unban (DELETE) untuk " + ruleKey + " dengan idx: " + idx);
           delete activeRules[ruleKey];
         } catch (e) {
           logWarning("\u274C Gagal hapus rule: " + delUrl + " \u2192 " + e);


### PR DESCRIPTION
## Summary
- correct delete icon escape sequence in metrics.js

## Testing
- `node -c scripts/metrics.js`


------
https://chatgpt.com/codex/tasks/task_e_6886e7a13b988332acfa2fe22fff3a2b