### PR TITLE
Enable firewall debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,21 @@ http://blog.sflow.com/2015/09/real-time-analytics-and-control.html
 2. Run command: `sflow-rt/get-app.sh sflow-rt dashboard-example`
 3. Restart sFlow-RT
 
+The dashboard now includes an *Attack List* panel that shows current UDP
+flows. Each entry displays source and destination IP/port as well as the
+traffic in bits per second and packets per second. Access the live attack
+data using the REST endpoint `../scripts/metrics.js/attacks/json`.
+
+When a UDP flow exceeds **10,000 packets per second**, a firewall rule is
+automatically created via the `/filters` REST API. Rules are removed after
+five minutes.
+
+Use the browser console to manually test rule creation by calling the
+`debugCreateRule('source_ip', 'destination_ip')` function. Replace the
+arguments with the actual addresses you want to test. The dashboard logs
+the request and response. The helper calls the `../scripts/metrics.js/filter`
+endpoint on the sFlow-RT server which proxies the request to the firewall,
+avoiding cross-origin errors in the browser.
+
 For more information, visit:
 http://www.sFlow-RT.com

--- a/html/css/app.css
+++ b/html/css/app.css
@@ -8,3 +8,15 @@ div.slider {
     padding-left:50px;
     background-color:white;
 }
+#attackTable {
+    width:100%;
+    border-collapse: collapse;
+}
+#attackTable th, #attackTable td {
+    border: 1px solid #ccc;
+    padding: 2px 4px;
+    text-align: left;
+}
+#attackTable th {
+    background-color: #f0f0f0;
+}

--- a/html/index.html
+++ b/html/index.html
@@ -38,6 +38,24 @@
             <div id="topprotocols" class="trend"></div>
           </div>
         </div>
+        <div>
+          <h3>Attack List</h3>
+          <div>
+            <table id="attackTable">
+              <thead>
+                <tr>
+                  <th>Src IP</th>
+                  <th>Src Port</th>
+                  <th>Dst IP</th>
+                  <th>Dst Port</th>
+                  <th>Bps</th>
+                  <th>PPS</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
       </div>
     </div>
     <div id="about">

--- a/scripts/metrics.js
+++ b/scripts/metrics.js
@@ -10,10 +10,46 @@ var trend = new Trend(300,1);
 var points;
 
 var SEP = '_SEP_';
+var FLOW_INTERVAL = 2; // seconds
+
+// firewall REST API details
+var FIREWALL_URL = 'http://192.168.10.102/filters';
+var FIREWALL_TOKEN = 'changeme';
+var FIREWALL_DEBUG = true;
+
+function fwLog(msg) {
+  if(FIREWALL_DEBUG) logInfo('FWDBG ' + msg);
+}
 
 // define flows, prepend application name to avoid name clashes with other apps
-setFlow('dashboard_example_bytes', {value:'bytes',t:2, fs: SEP});
-setFlow('dashboard_example_stack', {keys:'stack', value:'bytes', n:10, t:2, fs:SEP}); 
+setFlow('dashboard_example_bytes', {value:'bytes',t:FLOW_INTERVAL, fs: SEP});
+setFlow('dashboard_example_stack', {keys:'stack', value:'bytes', n:10, t:FLOW_INTERVAL, fs:SEP});
+// capture udp flows for attack visibility
+setFlow('dashboard_example_ddos',
+  {keys:'ipsource,udpsourceport,ipdestination,udpdestinationport',
+   value:'bytes', n:20, t:FLOW_INTERVAL, fs:SEP, filter:'ipprotocol=17'});
+setFlow('dashboard_example_ddos_pkts',
+  {keys:'ipsource,udpsourceport,ipdestination,udpdestinationport',
+   value:'frames', n:20, t:FLOW_INTERVAL, fs:SEP, filter:'ipprotocol=17'});
+
+// flow and threshold for automatic firewall mitigation
+setFlow('udp_ddos', {
+  keys: 'ipdestination,ipsource,udpdestinationport',
+  value: 'frames',
+  filter: 'direction=ingress&ipprotocol=17&udpsourceport!=0',
+  t: FLOW_INTERVAL
+});
+
+// Trigger when more than 10,000 packets per second are seen for a flow
+// FLOW_INTERVAL is two seconds, so threshold value is 10kpps * 2 seconds
+setThreshold('udp_ddos', {
+  metric: 'udp_ddos',
+  value: 20000,
+  byFlow: true,
+  timeout: 30
+});
+
+var activeRules = {};  // Format: key = sip-dip -> value = idx
 
 var other = '-other-';
 function calculateTopN(metric,n,minVal,total_bps) {     
@@ -56,9 +92,64 @@ setHttpHandler(function(req) {
      
   switch(path[0]) {
     case 'trend':
-      if(path.length > 1) throw "not_found"; 
+      if(path.length > 1) throw "not_found";
       result = {};
       result.trend = req.query.after ? trend.after(parseInt(req.query.after)) : trend;
+      break;
+    case 'attacks':
+      if(path.length > 1) throw "not_found";
+      var topBytes = activeFlows('ALL','dashboard_example_ddos',20,0,'sum');
+      var topPkts = activeFlows('ALL','dashboard_example_ddos_pkts',20,0,'sum');
+      var pktMap = {};
+      result = [];
+      if(topPkts) {
+        for(var j = 0; j < topPkts.length; j++) {
+          pktMap[topPkts[j].key] = topPkts[j].value;
+        }
+      }
+      if(topBytes) {
+        for(var i = 0; i < topBytes.length; i++) {
+          var key = topBytes[i].key;
+          var fields = key.split(SEP);
+          result.push({
+            ipsource: fields[0],
+            udpsourceport: fields[1],
+            ipdestination: fields[2],
+            udpdestinationport: fields[3],
+            bps: 8 * topBytes[i].value,
+            pps: pktMap[key] ? Math.round(pktMap[key] / FLOW_INTERVAL) : 0
+          });
+        }
+      }
+      break;
+    case 'filter':
+      if(path.length > 1) throw 'not_found';
+      var sip, dip;
+      if(req.method && req.method.toUpperCase() === 'POST') {
+        try {
+          var body = req.body || req.data || '';
+          if(body) {
+            var obj = JSON.parse(body);
+            sip = obj.sip;
+            dip = obj.dip;
+          }
+        } catch(e) {
+          throw 'bad_request';
+        }
+      } else {
+        sip = req.query.sip;
+        dip = req.query.dip;
+      }
+      if(!sip || !dip) throw 'bad_request';
+      var payload = {enabled:true, log:true, action:0, sip:sip, dip:dip};
+      var headers = {
+        'Authorization': 'Bearer ' + FIREWALL_TOKEN,
+        'Content-Type': 'application/json'
+      };
+      fwLog('PROXY POST ' + FIREWALL_URL + ' payload=' + JSON.stringify(payload));
+      var r = http(FIREWALL_URL, 'POST', JSON.stringify(payload), 'application/json', headers);
+      fwLog('PROXY RESP ' + r);
+      result = JSON.parse(r);
       break;
     case 'metric':
       if(path.length == 1) result = points;
@@ -72,4 +163,65 @@ setHttpHandler(function(req) {
   } 
   return result;
 });
+
+setEventHandler(function(evt) {
+  var parts = evt.flowKey.split(',');
+  var dip = parts[0];
+  var sip = parts[1];
+
+  var ruleKey = sip + '-' + dip;
+  if (activeRules[ruleKey]) {
+    logInfo("\u23F1\uFE0F Rule sudah aktif untuk " + ruleKey);
+    return;
+  }
+
+  var payload = {
+    enabled: true,
+    log: true,
+    action: 0,
+    sip: sip,
+    dip: dip
+  };
+
+  // firewall REST API endpoint and token
+  var url = FIREWALL_URL;
+  var token = FIREWALL_TOKEN;
+  var headers = {
+    "Authorization": "Bearer " + token,
+    "Content-Type": "application/json"
+  };
+
+  fwLog('POST ' + url + ' payload=' + JSON.stringify(payload));
+
+  try {
+    var response = http(url, 'POST', JSON.stringify(payload), 'application/json', headers);
+    fwLog('RESPONSE ' + response);
+    var obj = JSON.parse(response);
+
+    if (obj && obj.result === 'ok' && obj.idx !== undefined) {
+      var idx = obj.idx;
+      activeRules[ruleKey] = idx;
+      logInfo("\u2705 Rule dibuat untuk " + ruleKey + " dengan idx: " + idx);
+
+      setTimeout(function() {
+        var delUrl = url + '/' + idx;
+        try {
+          http(delUrl, 'DELETE', null, null, headers);
+          fwLog('DELETE ' + delUrl);
+          logInfo("\u1F5D1\uFE0F Rule auto-unban (DELETE) untuk " + ruleKey + " dengan idx: " + idx);
+          delete activeRules[ruleKey];
+        } catch (e) {
+          logWarning("\u274C Gagal hapus rule: " + delUrl + " \u2192 " + e);
+        }
+      }, 5 * 60 * 1000);
+
+    } else {
+      logWarning("\u274C Format response tidak sesuai: " + response);
+    }
+
+  } catch (e) {
+    logWarning("\u274C Error POST rule: " + e);
+  }
+
+}, ['udp_ddos']);
 


### PR DESCRIPTION
## Summary
- expose firewall URL and token in client script
- add browser helper `debugCreateRule()`
- log firewall API requests/responses from sFlow-RT scripts
- clarify how to call `debugCreateRule()` from the console
- proxy firewall requests via `scripts/metrics.js/filter` so browser debugging bypasses CORS
- fix the filter handler to accept POSTed JSON from `debugCreateRule`

## Testing
- `node --check html/js/app.js && node --check scripts/metrics.js`


------
https://chatgpt.com/codex/tasks/task_e_688477c3bae48332a9509a3fb4ed9aeb